### PR TITLE
Monkey-patches Enumberable: fixes issue #4

### DIFF
--- a/lib/peach.rb
+++ b/lib/peach.rb
@@ -44,36 +44,6 @@ module Peach
     result
   end
 
-
-
-  protected
-  def peach_run(meth, b, n = nil)
-    threads, results, result = [],[],[]
-    peach_divvy(n).each_with_index do |x,i|
-      threads << Thread.new { results[i] = x.send(meth, &b)}
-    end
-    threads.each {|t| t.join }
-    results.each {|x| result += x if x}
-    result
-  end
-  
-  def peach_divvy(n = nil)
-    return [] if size == 0
-
-    n ||= $peach_default_threads || size
-    n = size if n > size
-
-    lists = []
-
-    div = (size/n).floor
-    offset = 0
-    for i in (0...n-1)
-      lists << slice(offset, div)
-      offset += div
-    end
-    lists << slice(offset...size)
-    lists
-  end
 end
 
 Array.send(:include, Peach)

--- a/lib/peach.rb
+++ b/lib/peach.rb
@@ -1,14 +1,12 @@
 module Peach
   def peach(pool = nil, &b)
-    pool ||= $peach_default_threads || size
+    pool ||= $peach_default_threads || count
     raise "Thread pool size less than one?" unless pool >= 1
-    div = (size/pool).to_i      # should already be integer
+    div = (count/pool).to_i      # should already be integer
     div = 1 unless div >= 1     # each thread better do something!
-
-    threads = (0...size).step(div).map do |chunk|
-      Thread.new(chunk, [chunk+div,size].min) do |lower, upper|
-        (lower...upper).each{|j| yield(slice(j))}
-      end
+    threads = []
+    self.each_slice(div) do |slice|
+      threads << Thread.new(slice){|thread_slice| thread_slice.each{|elt| yield elt}}
     end
     threads.each { |t| t.join }
     self

--- a/lib/peach.rb
+++ b/lib/peach.rb
@@ -6,7 +6,7 @@ module Peach
     div = 1 unless div >= 1     # each thread better do something!
     
     threads = []
-    self.each_slice(div) do |slice|
+    each_slice(div) do |slice|
       threads << Thread.new(slice){|thread_slice| thread_slice.each{|elt| yield elt}}
     end
     threads.each { |t| t.join }
@@ -22,7 +22,7 @@ module Peach
     result = Array.new(count)
 
     threads = []
-    self.each_slice(div).with_index do |slice, idx|
+    each_slice(div).with_index do |slice, idx|
       threads << Thread.new(slice){|thread_slice| thread_slice.each_with_index{|elt, offset| result[idx+offset] = yield elt}}
     end
     threads.each { |t| t.join }

--- a/lib/peach.rb
+++ b/lib/peach.rb
@@ -1,5 +1,5 @@
-# monkey patch Enumerable directly. Enumerable.send(:include, Peach) doesn't
-# seem to work as it should.  
+# monkey patch Enumerable by reopening it. Enumerable.send(:include, Peach) 
+# doesn't seem to work as it should.  
 module Enumerable
   def peach(pool = nil, &b)
     pool ||= $peach_default_threads || count

--- a/lib/peach.rb
+++ b/lib/peach.rb
@@ -1,4 +1,6 @@
-module Peach
+# monkey patch Enumerable directly. Enumerable.send(:include, Peach) doesn't
+# seem to work as it should.  
+module Enumerable
   def peach(pool = nil, &b)
     pool ||= $peach_default_threads || count
     raise "Thread pool size less than one?" unless pool >= 1
@@ -45,5 +47,3 @@ module Peach
   end
 
 end
-
-Array.send(:include, Peach)

--- a/lib/peach.rb
+++ b/lib/peach.rb
@@ -9,7 +9,9 @@ module Enumerable
     
     threads = []
     each_slice(div) do |slice|
-      threads << Thread.new(slice){|thread_slice| thread_slice.each{|elt| yield elt}}
+      threads << Thread.new(slice) do |thread_slice|
+        thread_slice.each{|elt| yield elt}
+      end
     end
     threads.each { |t| t.join }
     self
@@ -25,7 +27,9 @@ module Enumerable
 
     threads = []
     each_slice(div).with_index do |slice, idx|
-      threads << Thread.new(slice){|thread_slice| thread_slice.each_with_index{|elt, offset| result[idx+offset] = yield elt}}
+      threads << Thread.new(slice) do |thread_slice|
+        thread_slice.each_with_index{|elt, offset| result[idx+offset] = yield elt}
+      end
     end
     threads.each { |t| t.join }
     result
@@ -39,7 +43,9 @@ module Enumerable
     threads, results, result = [],[],[]
 
     each_slice(div).with_index do |slice, idx|
-      threads << Thread.new(slice){|thread_slice| results[idx] = slice.select(&b)}
+      threads << Thread.new(slice) do |thread_slice|
+        results[idx] = slice.select(&b)
+      end
     end
     threads.each {|t| t.join }
     results.each {|x| result += x if x}

--- a/test/peach_test.rb
+++ b/test/peach_test.rb
@@ -38,39 +38,4 @@ class PeachTest < Test::Unit::TestCase
     end
   end
 
-  context "divvy" do
-    setup do
-      @data = [1, 2, 3, 4, 5]
-    end
-
-    context "on empty list" do
-      should "return empty list" do
-        assert_equal [], [].send(:peach_divvy)
-      end
-    end
-
-    context "when n is nil" do
-      should "put 1 element into each division" do
-        assert_equal @data.size, @data.send(:peach_divvy).size
-      end
-    end
-
-    context "when n is less than array size" do
-      should "put create n divisions" do
-        assert_equal 2, @data.send(:peach_divvy, 2).size
-      end
-
-      should "not lose any array elements" do
-        assert_equal @data.size, @data.send(:peach_divvy, 2).inject(0) {|sum, i|
-          sum + i.size
-        }
-      end
-    end
-
-    context "when n is greater than array size" do
-      should "only create 'array size' divisions" do
-        assert_equal @data.size, @data.send(:peach_divvy, 42).size
-      end
-    end
-  end
 end


### PR DESCRIPTION
Have modified peach.rb to remove calls to slice and count, and modified the code so it works with `Enumerable`. Rather than get `Array` to include the module, peach.rb now opens `Enumerable` directly and defines the Peach methods (I tried doing `Enumerable.send(:include, Peach)` but that only worked if `peach` was `require`'d from within the same directory it was located in). This fixes issue #4.

When I rewrote `#pselect` to work with `Enumerable`, I no longer needed to use `divvy`, so I removed that and its tests also (though all the methods do the same thing when calculating the chunk size, so a similar method might be extracted out to DRY up the code somewhat). 
