### PR TITLE
Making Hash#pselect work the same as Hash#select

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,15 +6,29 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    rake (0.9.2.2)
-    shoulda (3.0.1)
-      shoulda-context (~> 1.0.0)
-      shoulda-matchers (~> 1.0.0)
-    shoulda-context (1.0.0)
-    shoulda-matchers (1.0.0)
+    activesupport (4.0.2)
+      i18n (~> 0.6, >= 0.6.4)
+      minitest (~> 4.2)
+      multi_json (~> 1.3)
+      thread_safe (~> 0.1)
+      tzinfo (~> 0.3.37)
+    atomic (1.1.14-java)
+    i18n (0.6.9)
+    minitest (4.7.5)
+    multi_json (1.8.2)
+    rake (10.1.1)
+    shoulda (3.5.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (>= 1.4.1, < 3.0)
+    shoulda-context (1.1.6)
+    shoulda-matchers (2.4.0)
+      activesupport (>= 3.0.0)
+    thread_safe (0.1.3-java)
+      atomic
+    tzinfo (0.3.38)
 
 PLATFORMS
-  ruby
+  java
 
 DEPENDENCIES
   peach!

--- a/lib/peach.rb
+++ b/lib/peach.rb
@@ -39,7 +39,7 @@ module Enumerable
   end
 
   def pselect(pool = nil, &b)
-    results, result = [],[]
+    results = []
     lock = Mutex.new
 
     _peach_run(pool) do |thread_slice, idx, div|
@@ -48,7 +48,14 @@ module Enumerable
         results[idx] = local_result
       end
     end
-    results.each {|x| result += x if x}
-    result
+    results.reduce([]) {|result, x| result += x if x}
+  end
+end
+
+class Hash
+  alias_method :_pselect, :pselect
+
+  def pselect(pool = nil, &b)
+    Hash[_pselect(pool, &b)]
   end
 end

--- a/test/peach_test.rb
+++ b/test/peach_test.rb
@@ -43,4 +43,23 @@ class PeachTest < Test::Unit::TestCase
     end
   end
 
+  [:peach, :pmap, :pselect].each do |f|
+    context "Parallel function Hash##{f}" do
+      normal_f = f.to_s[1..-1].to_sym
+
+      setup do
+        @data = ([1, 2, 3, 5, 8]*1001).each_with_object({}){|n, out| out[n] = n}
+        @block = lambda{|k,v| v**2}
+      end
+      should "return the same result as Hash##{normal_f}" do
+        assert_equal @data.send(normal_f, &@block),
+                     @data.send(f, 100, &@block)
+      end
+
+      should "return the same result as Hash##{normal_f} when empty" do
+        assert_equal Hash.new.send(normal_f, &@block),
+                     Hash.new.send(f, nil, &@block)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When using pselect on hashes, the return is an array of arrays

``` ruby
[['key1', 'value1'], ['key2', 'value2'], ...]
```

This differs from Hash's implementation that returns a new hash.

``` ruby
{'key1' => 'value1', 'key2' => 'value2', ...}
```

This PR should resolve this disparity. 

Hash#select doc for reference
http://www.ruby-doc.org/core-2.1.0/Hash.html#method-i-select
