### PR TITLE
Fix broken link to homepage

### DIFF
--- a/peach.gemspec
+++ b/peach.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.authors = ['Ben Hughes']
   s.email = 'ben@pixelmachine.org'
   s.summary = 'Parallel Each and other parallel things'
-  s.homepage = 'http://peach.rubyforge.org'
+  s.homepage = 'https://github.com/schleyfox/peach'
   
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
It would be nice if a new version could be released so that the homepage link (on rubygems: https://rubygems.org/gems/peach/versions/0.5.1 ) points to this project -- it's not immediately clear that `Ben Hughes` and `schleyfox` are the same individual.